### PR TITLE
fix(utils): Allows numbers as strings

### DIFF
--- a/src/angularODataConfiguration.ts
+++ b/src/angularODataConfiguration.ts
@@ -52,7 +52,7 @@ export class ODataConfiguration {
         return this.baseUrl + '/' + this.sanitizeTypeName(typeName);
     }
 
-    public getEntityUri(entityKey: string | number, typeName: string): string {
+    public getEntityUri(entityKey: string | number | boolean, typeName: string): string {
         return this.getEntitiesUri(typeName) + `(${ODataUtils.quoteValue(entityKey)})`;
     }
 

--- a/src/angularODataConfiguration.ts
+++ b/src/angularODataConfiguration.ts
@@ -52,7 +52,7 @@ export class ODataConfiguration {
         return this.baseUrl + '/' + this.sanitizeTypeName(typeName);
     }
 
-    public getEntityUri(entityKey: string, typeName: string): string {
+    public getEntityUri(entityKey: string | number, typeName: string): string {
         return this.getEntitiesUri(typeName) + `(${ODataUtils.quoteValue(entityKey)})`;
     }
 

--- a/src/angularODataUtils.ts
+++ b/src/angularODataUtils.ts
@@ -12,18 +12,18 @@ export class ODataUtils {
         return properties.join(', ');
     }
 
-    public static quoteValue(value: string): string {
+    public static quoteValue(value: number | string | boolean): string {
+        // check if string
+        if (typeof value !== 'string') {
+            return `${value}`;
+        }
+
         // check if GUID (UUID) type
         if (/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)) {
             return value;
         }
 
-        // check if not a number
-        const valueAsNumber: number = Number(value);
-        if (isNaN(valueAsNumber)) {
-            return `'${value}'`;
-        }
-
-        return value;
+        const escaped = value.replace('\'', '\'\'');
+        return `'${escaped}'`;
     }
 }

--- a/test/angularODataConfiguration.spec.ts
+++ b/test/angularODataConfiguration.spec.ts
@@ -94,7 +94,7 @@ describe('ODataConfiguration', () => {
         config.baseUrl = 'http://test.org/odata';
 
         // Act
-        const result = config.getEntityUri('123', 'Employees');
+        const result = config.getEntityUri(123, 'Employees');
 
         // Assert
         assert.equal(result, 'http://test.org/odata/Employees(123)');

--- a/test/angularODataUtils.spec.ts
+++ b/test/angularODataUtils.spec.ts
@@ -19,6 +19,14 @@ describe('ODataUtils', () => {
         assert.equal(value, `'te\'\'st'`);
     });
 
+    it('quoteValue boolean', () => {
+        // Act
+        const value: string = ODataUtils.quoteValue(true);
+
+        // Assert
+        assert.equal(value, `true`);
+    });
+
     it('quoteValue integer', () => {
         // Act
         const value: string = ODataUtils.quoteValue(10);

--- a/test/angularODataUtils.spec.ts
+++ b/test/angularODataUtils.spec.ts
@@ -11,9 +11,17 @@ describe('ODataUtils', () => {
         assert.equal(value, `'test'`);
     });
 
+    it('quoteValue string with quotes', () => {
+        // Act
+        const value: string = ODataUtils.quoteValue('te\'st');
+
+        // Assert
+        assert.equal(value, `'te\'\'st'`);
+    });
+
     it('quoteValue integer', () => {
         // Act
-        const value: string = ODataUtils.quoteValue('10');
+        const value: string = ODataUtils.quoteValue(10);
 
         // Assert
         assert.equal(value, '10');
@@ -21,7 +29,7 @@ describe('ODataUtils', () => {
 
     it('quoteValue double', () => {
         // Act
-        const value: string = ODataUtils.quoteValue('-10.01');
+        const value: string = ODataUtils.quoteValue(-10.01);
 
         // Assert
         assert.equal(value, '-10.01');


### PR DESCRIPTION
Currently numeric strings are serialized as numbers to function parameters. This is not always the desired behavior. Sometimes you just want a string with digits in it. 😄 

This changes the behavior so that strings are strings and numbers are numbers. #26

Additionally this properly escapes single quotes in strings. #27
