### PR TITLE
fix(utils): Omits undefined values from serialized params

### DIFF
--- a/src/angularODataUtils.ts
+++ b/src/angularODataUtils.ts
@@ -3,8 +3,8 @@ export class ODataUtils {
         const properties: string[] = [];
 
         for (const prop in obj) {
-            if (obj.hasOwnProperty(prop)) {
-                const value: string = this.quoteValue(obj[prop]);
+            if (obj.hasOwnProperty(prop) && obj[prop] !== undefined) {
+                const value = this.quoteValue(obj[prop]);
 
                 properties.push(`${prop}=${value}`);
             }

--- a/test/angularODataUtils.spec.ts
+++ b/test/angularODataUtils.spec.ts
@@ -37,7 +37,8 @@ describe('ODataUtils', () => {
 
     it('convertObjectToString', () => {
         // Act
-        const value: string = ODataUtils.convertObjectToString({ str: 'abc', int: 10, double: -10.01, guid: 'eefea99a-c988-44b8-ac37-b326a489c1e3' });
+        const value: string = ODataUtils.convertObjectToString(
+          { str: 'abc', int: 10, double: -10.01, guid: 'eefea99a-c988-44b8-ac37-b326a489c1e3', omitted: undefined });
 
         // Assert
         assert.equal(value, `str='abc', int=10, double=-10.01, guid=eefea99a-c988-44b8-ac37-b326a489c1e3`);


### PR DESCRIPTION
Undefined is a valid value in an object, but not in a parameter. Therefore it would be helpful if `convertObjectToString` simply omitted them. #28 