### PR TITLE
Remove RxJs compatibility package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8037,9 +8037,9 @@
       "dev": true
     },
     "primeng": {
-      "version": "5.2.7",
-      "resolved": "https://registry.npmjs.org/primeng/-/primeng-5.2.7.tgz",
-      "integrity": "sha512-7TyD4zEhG00LK2oJRl8rhBpLD/3HUhc2Yicj0G/H2xQGw7CP8Kx9dUBStQ2ebOhlV6o8GHB5hAXI/fISG6ocpw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/primeng/-/primeng-6.0.1.tgz",
+      "integrity": "sha512-lwh613WHhk7yrcOeGvT3ciG+/aH9nx78QUVbaAydIcR52pyj1tNHLgsldc0Gs1eraELoIr+GXi1HtMwtuH4YCQ==",
       "dev": true
     },
     "process": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-odata-es5",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8528,11 +8528,6 @@
           "dev": true
         }
       }
-    },
-    "rxjs-compat": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.2.0.tgz",
-      "integrity": "sha512-kFX7NSIgyzqn3+J5F/w75R72wDOICXwArbXyPU1neE4laOEwxkMTm+2oAZXN82yb+yli+j+c5USgbGLfphTCTA=="
     },
     "safe-buffer": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
   },
   "dependencies": {
     "@angular/cli": "^6.0.7",
-    "linq-collections": "^1.0.249",
-    "rxjs-compat": "^6.2.0"
+    "linq-collections": "^1.0.249"
   }
 }

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^2.0.3",
     "phantomjs-prebuilt": "^2.1.14",
-    "primeng": "^5.2.7",
+    "primeng": "^6.0.1",
     "rxjs": "^6.2.0",
     "sinon": "^2.1.0",
     "sinon-chai": "^2.8.0",

--- a/src/angularODataOperation.ts
+++ b/src/angularODataOperation.ts
@@ -1,7 +1,7 @@
 import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/common/http';
 import { Dictionary, IEnumerable, IQueryable, List } from 'linq-collections';
 
-import { Observable } from 'rxjs';
+import { Observable, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { ODataConfiguration } from './angularODataConfiguration';
 
@@ -81,7 +81,7 @@ export abstract class ODataOperation<T> {
                     if (this.config.handleError) {
                         this.config.handleError(err, caught);
                     }
-                    return Observable.throw(err);
+                    return throwError(err);
                 })
             );
     }

--- a/src/angularODataQuery.ts
+++ b/src/angularODataQuery.ts
@@ -1,4 +1,4 @@
-import { Observable } from 'rxjs';
+import { Observable, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
 import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/common/http';
@@ -80,7 +80,7 @@ export class ODataQuery<T> extends ODataOperation<T> {
                             if (this.config.handleError) {
                                 this.config.handleError(err, caught);
                             }
-                            return Observable.throw(err);
+                            return throwError(err);
                         })
                     );
 
@@ -92,7 +92,7 @@ export class ODataQuery<T> extends ODataOperation<T> {
                             if (this.config.handleError) {
                                 this.config.handleError(err, caught);
                             }
-                            return Observable.throw(err);
+                            return throwError(err);
                         })
                     );
 
@@ -104,7 +104,7 @@ export class ODataQuery<T> extends ODataOperation<T> {
                             if (this.config.handleError) {
                                 this.config.handleError(err, caught);
                             }
-                            return Observable.throw(err);
+                            return throwError(err);
                         })
                     );
         }

--- a/src/angularODataService.ts
+++ b/src/angularODataService.ts
@@ -1,4 +1,4 @@
-import { Observable } from 'rxjs';
+import { Observable, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
 import { HttpClient, HttpResponse } from '@angular/common/http';
@@ -88,7 +88,7 @@ export class ODataService<T> {
                     if (this.config.handleError) {
                         this.config.handleError(err, caught);
                     }
-                    return Observable.throw(err);
+                    return throwError(err);
                 })
             );
     }


### PR DESCRIPTION
- Closes issue #59 
- Removes `rxjs-compat` package
- Upgrades PrimeNG to latest with Angular 6 support