### PR TITLE
Allow ability to expand children on POST/PUT/PATCH calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Bug Fixes
 
-* Actions are http's post methods, so they needs postRequestOptions ([#52](https://github.com/StefH/angular-odata-es5/issues/52)) ([7dc15c3](https://github.com/StefH/angular-odata-es5/commit/7dc15c3))
+* Actions are http's post methods, so they needs customRequestOptions ([#52](https://github.com/StefH/angular-odata-es5/issues/52)) ([7dc15c3](https://github.com/StefH/angular-odata-es5/commit/7dc15c3))
 
 
 

--- a/demo/NorthwindODataConfigurationFactory.ts
+++ b/demo/NorthwindODataConfigurationFactory.ts
@@ -8,8 +8,8 @@ export class NorthwindODataConfigurationFactory {
         const config = new ODataConfiguration();
         config.baseUrl = 'https://odatateststef.azurewebsites.net/odata';
 
-        // Set some new `postRequestOptions` here as an example
-        config.postRequestOptions.headers = new HttpHeaders({
+        // Set some new `customRequestOptions` here as an example
+        config.customRequestOptions.headers = new HttpHeaders({
             'Content-Type': 'application/json; charset=utf-8',
             'Session': '123'
         });

--- a/demo/employeeGridOData.component.ts
+++ b/demo/employeeGridOData.component.ts
@@ -5,7 +5,6 @@ import { FilterMetadata, LazyLoadEvent } from 'primeng/primeng';
 import { ODataConfiguration, ODataExecReturnType, ODataPagedResult, ODataQuery, ODataService, ODataServiceFactory } from '../src/index';
 import { IEmployee } from '../test/helpers/employee';
 import { NorthwindODataConfigurationFactory } from './NorthwindODataConfigurationFactory';
-import { PostEmployeeResult } from './postEmployeeResult.model';
 
 console.log('`EmployeeGridODataComponent` component loaded asynchronously');
 
@@ -49,8 +48,9 @@ export class EmployeeGridODataComponent implements OnInit {
             LastName: 'l',
             City: 'c'
         };
-        this.odata.Post<PostEmployeeResult>(employee)
-            .subscribe((result: PostEmployeeResult) => {
+        this.odata.Post<IEmployee>(employee)
+            .Exec()
+            .subscribe((result: IEmployee) => {
                 console.log(result);
             }, (error) => {
                 console.log('Post ERROR ' + error);

--- a/demo/postEmployeeResult.model.ts
+++ b/demo/postEmployeeResult.model.ts
@@ -1,6 +1,0 @@
-import { IEmployee } from "../test/helpers/employee";
-import { IOrder } from "../test/helpers/order";
-
-export interface PostEmployeeResult extends IEmployee {
-    Headers: string[];
-}

--- a/src/angularODataConfiguration.ts
+++ b/src/angularODataConfiguration.ts
@@ -32,7 +32,7 @@ export class ODataConfiguration {
         withCredentials?: boolean;
     } = { observe: 'response' };
 
-    public postRequestOptions: {
+    public customRequestOptions: {
         headers?: HttpHeaders;
         observe: 'response';
         params?: HttpParams;

--- a/src/angularODataOperation.ts
+++ b/src/angularODataOperation.ts
@@ -191,9 +191,9 @@ export class PatchOperation<T> extends OperationWithKeyAndEntity<T>{
     }
 }
 
-// export class PutOperation<T> extends OperationWithKeyAndEntity<T>{
-//     public Exec(){
-//         let body = JSON.stringify(this.entity);
-//         return this.handleResponse(this.http.put(this.getEntityUri(this.key),body,this.getRequestOptions()));
-//     }
-// }
+export class PutOperation<T> extends OperationWithKeyAndEntity<T>{
+    public Exec() {
+        const body = this.entity ? JSON.stringify(this.entity) : null;
+        return super.handleResponse(this.http.put<T>(this.config.getEntityUri(this.entityKey, this.typeName), body, this.getRequestOptions()));
+    }
+}

--- a/src/angularODataOperation.ts
+++ b/src/angularODataOperation.ts
@@ -177,12 +177,12 @@ export class GetOperation<T> extends OperationWithKey<T> {
     }
 }
 
-// export class PostOperation<T> extends OperationWithEntity<T>{
-//     public Exec():Observable<T>{    //ToDo: Check ODataV4
-//         let body = JSON.stringify(this.entity);
-//         return this.handleResponse(this.http.post(this.config.baseUrl + "/"+this._typeName, body, this.getRequestOptions()));
-//     }
-// }
+export class PostOperation<T> extends OperationWithEntity<T>{
+    public Exec(): Observable<T> {
+        const body = this.entity ? JSON.stringify(this.entity) : null;
+        return super.handleResponse(this.http.post<T>(this.config.getEntitiesUri(this._typeName), body, this.getRequestOptions()));
+    }
+}
 
 // export class PatchOperation<T> extends OperationWithKeyAndEntity<T>{
 //     public Exec():Observable<Response>{    //ToDo: Check ODataV4

--- a/src/angularODataOperation.ts
+++ b/src/angularODataOperation.ts
@@ -184,12 +184,12 @@ export class PostOperation<T> extends OperationWithEntity<T>{
     }
 }
 
-// export class PatchOperation<T> extends OperationWithKeyAndEntity<T>{
-//     public Exec():Observable<Response>{    //ToDo: Check ODataV4
-//         let body = JSON.stringify(this.entity);
-//         return this.http.patch(this.getEntityUri(this.key),body,this.getRequestOptions());
-//     }
-// }
+export class PatchOperation<T> extends OperationWithKeyAndEntity<T>{
+    public Exec(): Observable<T> {
+        const body = this.entity ? JSON.stringify(this.entity) : null;
+        return super.handleResponse(this.http.patch<T>(this.config.getEntityUri(this.entityKey, this.typeName), body, this.getRequestOptions()));
+    }
+}
 
 // export class PutOperation<T> extends OperationWithKeyAndEntity<T>{
 //     public Exec(){

--- a/src/angularODataService.ts
+++ b/src/angularODataService.ts
@@ -4,7 +4,7 @@ import { catchError, map } from 'rxjs/operators';
 import { HttpClient, HttpResponse } from '@angular/common/http';
 
 import { ODataConfiguration } from './angularODataConfiguration';
-import { GetOperation, PatchOperation, PostOperation } from './angularODataOperation';
+import { GetOperation, PatchOperation, PostOperation, PutOperation } from './angularODataOperation';
 import { ODataQuery } from './angularODataQuery';
 import { ODataUtils } from './angularODataUtils';
 
@@ -31,9 +31,8 @@ export class ODataService<T> {
         return new PatchOperation<T>(this._typeName, this.config, this._http, key, entity);
     }
 
-    public Put<TResponse>(entity: T, key: any): Observable<TResponse> {
-        const body = entity ? JSON.stringify(entity) : null;
-        return this.handleResponse(this._http.put<TResponse>(this.getEntityUri(key), body, this.config.postRequestOptions));
+    public Put<T>(entity: T, key: any): PutOperation<T> {
+        return new PutOperation<T>(this._typeName, this.config, this._http, key, entity);
     }
 
     public Delete(key: any): Observable<HttpResponse<T>> {

--- a/src/angularODataService.ts
+++ b/src/angularODataService.ts
@@ -4,7 +4,7 @@ import { catchError, map } from 'rxjs/operators';
 import { HttpClient, HttpResponse } from '@angular/common/http';
 
 import { ODataConfiguration } from './angularODataConfiguration';
-import { GetOperation, PostOperation } from './angularODataOperation';
+import { GetOperation, PatchOperation, PostOperation } from './angularODataOperation';
 import { ODataQuery } from './angularODataQuery';
 import { ODataUtils } from './angularODataUtils';
 
@@ -27,9 +27,8 @@ export class ODataService<T> {
         return new PostOperation<T>(this._typeName, this.config, this._http, entity);
     }
 
-    public Patch(entity: any, key: any): Observable<HttpResponse<T>> {
-        const body = entity ? JSON.stringify(entity) : null;
-        return this._http.patch<T>(this.getEntityUri(key), body, this.config.postRequestOptions);
+    public Patch<T>(entity: T, key: any): PatchOperation<T> {
+        return new PatchOperation<T>(this._typeName, this.config, this._http, key, entity);
     }
 
     public Put<TResponse>(entity: T, key: any): Observable<TResponse> {

--- a/src/angularODataService.ts
+++ b/src/angularODataService.ts
@@ -41,12 +41,12 @@ export class ODataService<T> {
 
     public CustomAction(key: any, actionName: string, postdata: any): Observable<any> {
         const body = postdata ? JSON.stringify(postdata) : null;
-        return this._http.post(`${this.getEntityUri(key)}/${actionName}`, body, this.config.postRequestOptions).pipe(map(resp => resp));
+        return this._http.post(`${this.getEntityUri(key)}/${actionName}`, body, this.config.customRequestOptions).pipe(map(resp => resp));
     }
 
     public CustomCollectionAction(actionName: string, postdata: any): Observable<any> {
         const body = postdata ? JSON.stringify(postdata) : null;
-        return this._http.post(`${this._entitiesUri}/${actionName}`, body, this.config.postRequestOptions).pipe(map(resp => resp));
+        return this._http.post(`${this._entitiesUri}/${actionName}`, body, this.config.customRequestOptions).pipe(map(resp => resp));
     }
 
     public CustomFunction(key: any, functionName: string, parameters?: any): Observable<any> {

--- a/src/angularODataService.ts
+++ b/src/angularODataService.ts
@@ -4,7 +4,7 @@ import { catchError, map } from 'rxjs/operators';
 import { HttpClient, HttpResponse } from '@angular/common/http';
 
 import { ODataConfiguration } from './angularODataConfiguration';
-import { GetOperation } from './angularODataOperation';
+import { GetOperation, PostOperation } from './angularODataOperation';
 import { ODataQuery } from './angularODataQuery';
 import { ODataUtils } from './angularODataUtils';
 
@@ -23,9 +23,8 @@ export class ODataService<T> {
         return new GetOperation<T>(this._typeName, this.config, this._http, key);
     }
 
-    public Post<TResponse>(entity: T): Observable<TResponse> {
-        const body = entity ? JSON.stringify(entity) : null;
-        return this.handleResponse(this._http.post<TResponse>(this._entitiesUri, body, this.config.postRequestOptions));
+    public Post<T>(entity: T): PostOperation<T> {
+        return new PostOperation<T>(this._typeName, this.config, this._http, entity);
     }
 
     public Patch(entity: any, key: any): Observable<HttpResponse<T>> {

--- a/test/angularODataService.spec.ts
+++ b/test/angularODataService.spec.ts
@@ -143,17 +143,43 @@ describe('ODataService', () => {
         spyOn(http, 'post').and.returnValue(new Observable<Response>());
 
         // Act
-        const result = service.Post(employee);
+        const result = service.Post(employee).Exec();
 
         // Assert
         assert.isNotNull(result);
         expect(http.post).toHaveBeenCalledWith(`http://localhost/odata/Employees`, `{"EmployeeID":1,"FirstName":"f","LastName":"l","City":"c","BirthDate":null,"Orders":null,"Boss":null}`, jasmine.any(Object));
     }));
 
+    it('Post with expand', inject([HttpClient, ODataServiceFactory], (http: HttpClient, factory: ODataServiceFactory) => {
+        // Assign
+        const service = factory.CreateService<IEmployee>('Employees');
+        const employee: IEmployee = {
+            EmployeeID: 1,
+            FirstName: 'f',
+            LastName: 'l',
+            City: 'c',
+            BirthDate: null,
+            Orders: null,
+            Boss: null
+        };
+
+        spyOn(http, 'post').and.returnValue(new Observable<Response>());
+
+        // Act
+        const result = service.Post(employee).Expand('Boss').Exec();
+
+        // Assert
+        assert.isNotNull(result);
+
+        let httpParams: HttpParams = new HttpParams();
+        httpParams = httpParams.append('$expand', 'Boss');
+        expect(http.post).toHaveBeenCalledWith(`http://localhost/odata/Employees`, `{"EmployeeID":1,"FirstName":"f","LastName":"l","City":"c","BirthDate":null,"Orders":null,"Boss":null}`, jasmine.objectContaining({ params: httpParams }));
+    }));
+
     it('Post with custom headers', inject([HttpClient, ODataServiceFactory], (http: HttpClient, factory: ODataServiceFactory) => {
         // Assign
         const config = new ODataConfiguration();
-        config.postRequestOptions.headers = new HttpHeaders({ 'Session': 'abc' });
+        config.defaultRequestOptions.headers = new HttpHeaders({ 'Session': 'abc' });
 
         const service = factory.CreateService<IEmployee>('Employees', config);
         const employee: IEmployee = {
@@ -169,7 +195,7 @@ describe('ODataService', () => {
         spyOn(http, 'post').and.returnValue(new Observable<Response>());
 
         // Act
-        const result = service.Post<string>(employee);
+        const result = service.Post(employee).Exec();
 
         // Assert
         assert.isNotNull(result);

--- a/test/angularODataService.spec.ts
+++ b/test/angularODataService.spec.ts
@@ -219,7 +219,7 @@ describe('ODataService', () => {
         spyOn(http, 'patch').and.returnValue(new Observable<Response>());
 
         // Act
-        const result = service.Patch(employee, 'x');
+        const result = service.Patch(employee, 'x').Exec();
 
         // Assert
         assert.isNotNull(result);
@@ -233,11 +233,37 @@ describe('ODataService', () => {
         spyOn(http, 'patch').and.returnValue(new Observable<Response>());
 
         // Act
-        const result = service.Patch(null, 42);
+        const result = service.Patch(null, 42).Exec();
 
         // Assert
         assert.isNotNull(result);
         expect(http.patch).toHaveBeenCalledWith(`http://localhost/odata/Employees(42)`, null, jasmine.any(Object));
+    }));
+
+    it('Patch with expand', inject([HttpClient, ODataServiceFactory], (http: HttpClient, factory: ODataServiceFactory) => {
+        // Assign
+        const service = factory.CreateService<IEmployee>('Employees');
+        const employee: IEmployee = {
+            EmployeeID: 1,
+            FirstName: 'f',
+            LastName: 'l',
+            City: 'c',
+            BirthDate: null,
+            Orders: null,
+            Boss: null
+        };
+
+        spyOn(http, 'patch').and.returnValue(new Observable<Response>());
+
+        // Act
+        const result = service.Patch(employee, employee.EmployeeID).Expand('Boss').Exec();
+
+        // Assert
+        assert.isNotNull(result);
+
+        let httpParams: HttpParams = new HttpParams();
+        httpParams = httpParams.append('$expand', 'Boss');
+        expect(http.patch).toHaveBeenCalledWith(`http://localhost/odata/Employees(${employee.EmployeeID})`, `{"EmployeeID":1,"FirstName":"f","LastName":"l","City":"c","BirthDate":null,"Orders":null,"Boss":null}`, jasmine.objectContaining({ params: httpParams }));
     }));
 
     it('Delete with string key', inject([HttpClient, ODataServiceFactory], (http: HttpClient, factory: ODataServiceFactory) => {

--- a/test/angularODataService.spec.ts
+++ b/test/angularODataService.spec.ts
@@ -34,6 +34,16 @@ class HttpHeadersMatcher {
 }
 
 describe('ODataService', () => {
+    const employee: IEmployee = {
+        EmployeeID: 1,
+        FirstName: 'f',
+        LastName: 'l',
+        City: 'c',
+        BirthDate: null,
+        Orders: null,
+        Boss: null
+    };
+
     beforeEach(() => {
         TestBed.configureTestingModule({
             providers: [
@@ -153,15 +163,6 @@ describe('ODataService', () => {
     it('Post with expand', inject([HttpClient, ODataServiceFactory], (http: HttpClient, factory: ODataServiceFactory) => {
         // Assign
         const service = factory.CreateService<IEmployee>('Employees');
-        const employee: IEmployee = {
-            EmployeeID: 1,
-            FirstName: 'f',
-            LastName: 'l',
-            City: 'c',
-            BirthDate: null,
-            Orders: null,
-            Boss: null
-        };
 
         spyOn(http, 'post').and.returnValue(new Observable<Response>());
 
@@ -243,15 +244,6 @@ describe('ODataService', () => {
     it('Patch with expand', inject([HttpClient, ODataServiceFactory], (http: HttpClient, factory: ODataServiceFactory) => {
         // Assign
         const service = factory.CreateService<IEmployee>('Employees');
-        const employee: IEmployee = {
-            EmployeeID: 1,
-            FirstName: 'f',
-            LastName: 'l',
-            City: 'c',
-            BirthDate: null,
-            Orders: null,
-            Boss: null
-        };
 
         spyOn(http, 'patch').and.returnValue(new Observable<Response>());
 
@@ -358,15 +350,6 @@ describe('ODataService', () => {
     it('Put with expand', inject([HttpClient, ODataServiceFactory], (http: HttpClient, factory: ODataServiceFactory) => {
         // Assign
         const service = factory.CreateService<IEmployee>('Employees');
-        const employee: IEmployee = {
-            EmployeeID: 1,
-            FirstName: 'f',
-            LastName: 'l',
-            City: 'c',
-            BirthDate: null,
-            Orders: null,
-            Boss: null
-        };
 
         spyOn(http, 'put').and.returnValue(new Observable<Response>());
 

--- a/test/angularODataService.spec.ts
+++ b/test/angularODataService.spec.ts
@@ -319,7 +319,7 @@ describe('ODataService', () => {
         spyOn(http, 'put').and.returnValue(new Observable<Response>());
 
         // Act
-        const result = service.Put(employee, 'x');
+        const result = service.Put(employee, 'x').Exec();
 
         // Assert
         assert.isNotNull(result);
@@ -333,7 +333,7 @@ describe('ODataService', () => {
         spyOn(http, 'put').and.returnValue(new Observable<Response>());
 
         // Act
-        const result = service.Put(null, 42);
+        const result = service.Put(null, 42).Exec();
 
         // Assert
         assert.isNotNull(result);
@@ -348,11 +348,37 @@ describe('ODataService', () => {
         spyOn(http, 'put').and.returnValue(new Observable<Response>());
 
         // Act
-        const result = service.Put(employee, '3dde7303-5414-4af6-b96b-591f33d25445');
+        const result = service.Put(employee, '3dde7303-5414-4af6-b96b-591f33d25445').Exec();
 
         // Assert
         assert.isNotNull(result);
         expect(http.put).toHaveBeenCalledWith(`http://localhost/odata/Employees(3dde7303-5414-4af6-b96b-591f33d25445)`, '{}', jasmine.any(Object));
+    }));
+
+    it('Put with expand', inject([HttpClient, ODataServiceFactory], (http: HttpClient, factory: ODataServiceFactory) => {
+        // Assign
+        const service = factory.CreateService<IEmployee>('Employees');
+        const employee: IEmployee = {
+            EmployeeID: 1,
+            FirstName: 'f',
+            LastName: 'l',
+            City: 'c',
+            BirthDate: null,
+            Orders: null,
+            Boss: null
+        };
+
+        spyOn(http, 'put').and.returnValue(new Observable<Response>());
+
+        // Act
+        const result = service.Put(employee, employee.EmployeeID).Expand('Boss').Exec();
+
+        // Assert
+        assert.isNotNull(result);
+
+        let httpParams: HttpParams = new HttpParams();
+        httpParams = httpParams.append('$expand', 'Boss');
+        expect(http.put).toHaveBeenCalledWith(`http://localhost/odata/Employees(${employee.EmployeeID})`, `{"EmployeeID":1,"FirstName":"f","LastName":"l","City":"c","BirthDate":null,"Orders":null,"Boss":null}`, jasmine.objectContaining({ params: httpParams }));
     }));
 
     it('Query', inject([HttpClient, ODataServiceFactory, ODataConfiguration], (http: HttpClient, factory: ODataServiceFactory, config: ODataConfiguration) => {


### PR DESCRIPTION
Uncommented the Post/Put/PatchOperations in angularODataOperations then added some tests around the new functionality.

Renamed the `postRequestOptions` config property since it's only used on custom actions, etc.

Closes #61 