### PR TITLE
Fix quoteValue for GUID (current regex was valid only for UUID not GUID)

### DIFF
--- a/src/angularODataUtils.ts
+++ b/src/angularODataUtils.ts
@@ -14,7 +14,7 @@ export class ODataUtils {
 
     public static quoteValue(value: number | string | boolean | any): string {
         // check if GUID (UUID) type
-        if (/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)) {
+        if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)) {
             return value;
         }
 


### PR DESCRIPTION
Problem is that if you want to use with .NET which use GUID (not UUID) current regex for test whether value is GUID is not valid. Result is that for odata v 4 it is not valid URL (because of quoted guid in URL) for get/put/delete operations and server returns http status 404.