### PR TITLE
Check for truthy on Top and Skip

### DIFF
--- a/src/angularODataQuery.ts
+++ b/src/angularODataQuery.ts
@@ -34,7 +34,9 @@ export class ODataQuery<T> extends ODataOperation<T> {
     }
 
     public Top(top: number): ODataQuery<T> {
-        this._top = top;
+        if (top) {
+            this._top = top;
+        }
         return this;
     }
 

--- a/src/angularODataQuery.ts
+++ b/src/angularODataQuery.ts
@@ -41,7 +41,9 @@ export class ODataQuery<T> extends ODataOperation<T> {
     }
 
     public Skip(skip: number): ODataQuery<T> {
-        this._skip = skip;
+        if (skip) {
+            this._skip = skip;
+        }
         return this;
     }
 

--- a/test/angularODataQuery.spec.ts
+++ b/test/angularODataQuery.spec.ts
@@ -254,6 +254,17 @@ describe('ODataQuery', () => {
         assert.equal(test['_top'], 20);
     }));
 
+    it('Top(null)', inject([HttpClient, ODataConfiguration], (http: HttpClient, config: ODataConfiguration) => {
+        // Assign
+        const test = new ODataQueryMock('Employees', config, http);
+
+        // Act
+        test.Top(null);
+
+        // Assert
+        assert.equal(test['_top'], null);
+    }));
+
     it('Apply(string)', inject([HttpClient, ODataConfiguration], (http: HttpClient, config: ODataConfiguration) => {
         // Assign
         const test = new ODataQueryMock('Employees', config, http);

--- a/test/angularODataQuery.spec.ts
+++ b/test/angularODataQuery.spec.ts
@@ -243,6 +243,17 @@ describe('ODataQuery', () => {
         assert.equal(test['_skip'], 10);
     }));
 
+    it('Skip(null)', inject([HttpClient, ODataConfiguration], (http: HttpClient, config: ODataConfiguration) => {
+        // Assign
+        const test = new ODataQueryMock('Employees', config, http);
+
+        // Act
+        test.Skip(null);
+
+        // Assert
+        assert.equal(test['_skip'], null);
+    }));
+
     it('Top(number)', inject([HttpClient, ODataConfiguration], (http: HttpClient, config: ODataConfiguration) => {
         // Assign
         const test = new ODataQueryMock('Employees', config, http);


### PR DESCRIPTION
The other operations on the Query object were checking for truthy parameters, but these two weren't.

This would help clean up some of our code in practice 😃 

Closes #66 