### PR TITLE
fix: return correct url if entity name is empty

### DIFF
--- a/src/angularODataConfiguration.ts
+++ b/src/angularODataConfiguration.ts
@@ -61,7 +61,10 @@ export class ODataConfiguration {
     }
 
     public getEntitiesUri(typeName: string): string {
-        return `${this.baseUrl}/${this.sanitizeTypeName(typeName)}`;
+        if(typeName){
+            return `${this.baseUrl}/${this.sanitizeTypeName(typeName)}`;
+        }
+        return this.baseUrl;
     }
 
     public getEntityUri(key: any, typeName: string): string {

--- a/src/angularODataConfiguration.ts
+++ b/src/angularODataConfiguration.ts
@@ -61,7 +61,7 @@ export class ODataConfiguration {
     }
 
     public getEntitiesUri(typeName: string): string {
-        if(typeName){
+        if (typeName) {
             return `${this.baseUrl}/${this.sanitizeTypeName(typeName)}`;
         }
         return this.baseUrl;

--- a/test/angularODataConfiguration.spec.ts
+++ b/test/angularODataConfiguration.spec.ts
@@ -87,6 +87,18 @@ describe('ODataConfiguration', () => {
         assert.equal(result, 'http://test.org/odata/Employees');
     });
 
+    it('getEntitiesUri_emptyTypeName', () => {
+        // Assign
+        const config = new ODataConfiguration();
+        config.baseUrl = 'http://test.org/odata';
+
+        // Act
+        const result = config.getEntitiesUri('');
+
+        // Assert
+        assert.equal(result, 'http://test.org/odata');
+    });
+
     it('getEntityUri_number', () => {
         // Assign
         const config = new ODataConfiguration();


### PR DESCRIPTION
Can be useful in case calling method without entity